### PR TITLE
Update dependencies to fix node ~0.8.9 issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "node": "~0.6.9"
   },
   "dependencies": {
-    "libxmljs": "~0.6.0",
-    "node-proxy": "~0.5.2"
+    "libxmljs": "~0.6.1",
+    "node-proxy": "~0.6.0"
   },
   "devDependencies": {
     "mocha": "~0.11.0"


### PR DESCRIPTION
- Update libxmljs to version ~0.6.1
- Update node-proxy to version ~0.6.0

Issue : 

```
$ node main.js

module.js:340
    throw err;
          ^
Error: Cannot find module '../build/default/libxmljs'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (.../node_modules/libxmljs-easy/node_modules/libxmljs/lib/bindings.js:6:22)
   at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:362:17)
```
