### PR TITLE
Added ability to pass options to libxml.

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,8 +51,8 @@ var handlerMaker = require("./handler-maker");
 //      assert.equal(xml.book.language[0].$.text(), "English");
 //
 //
-exports.parse = function(str) {
-    var xml = libxml.parseXmlString(str);
+exports.parse = function(str, options) {
+    var xml = libxml.parseXmlString(str, options);
 
     return convertElement(xml.root());
 }


### PR DESCRIPTION
libxmljs-easy can currently bomb out on large XML files due to the inability to set the XML_PARSE_HUGE flag in libxmljs's options. This allows for passing options to libxmljs.
